### PR TITLE
Adding admin-scp feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## 1.0.1 (Unreleased)
 ## 1.0.0 (April 18, 2019)
 
 FEATURES:

--- a/fortios/resource_system_setting_global.go
+++ b/fortios/resource_system_setting_global.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/fgtdev/fortios-sdk-go/sdkcore"
+	forticlient "github.com/fgtdev/fortios-sdk-go/sdkcore"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -40,6 +40,11 @@ func resourceSystemSettingGlobal() *schema.Resource {
 				Optional: true,
 				Default:  "22",
 			},
+			"admin_scp": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "disable",
+			},
 		},
 	}
 }
@@ -56,6 +61,7 @@ func resourceSystemSettingGlobalCreateUpdate(d *schema.ResourceData, m interface
 	hostname := d.Get("hostname").(string)
 	adminSport := d.Get("admin_sport").(string)
 	adminSSHPort := d.Get("admin_ssh_port").(string)
+	adminScp := d.Get("admin_scp").(string)
 
 	//Build input data by sdk
 	i := &forticlient.JSONSystemSettingGlobal{
@@ -64,6 +70,7 @@ func resourceSystemSettingGlobalCreateUpdate(d *schema.ResourceData, m interface
 		Hostname:     hostname,
 		AdminSport:   adminSport,
 		AdminSSHPort: adminSSHPort,
+		AdminScp:     adminScp,
 	}
 
 	//Call process by sdk
@@ -106,6 +113,7 @@ func resourceSystemSettingGlobalRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("hostname", o.Hostname)
 	d.Set("admin_sport", o.AdminSport)
 	d.Set("admin_ssh_port", o.AdminSSHPort)
+	d.Set("admin_scp", o.AdminScp)
 
 	return nil
 }

--- a/fortios/resource_system_setting_global_test.go
+++ b/fortios/resource_system_setting_global_test.go
@@ -23,6 +23,7 @@ func TestAccFortiOSSystemSettingGlobal_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("fortios_system_setting_global.test1", "hostname", "mytestFortiGate"),
 					resource.TestCheckResourceAttr("fortios_system_setting_global.test1", "admin_sport", "443"),
 					resource.TestCheckResourceAttr("fortios_system_setting_global.test1", "admin_ssh_port", "22"),
+					resource.TestCheckResourceAttr("fortios_system_setting_global.test1", "admin_scp", "disable"),
 				),
 			},
 		},
@@ -87,5 +88,6 @@ resource "fortios_system_setting_global" "test1" {
 	hostname = "mytestFortiGate"
 	admin_sport = 443
 	admin_ssh_port = 22
+	admin_scp = "disable"
 }
 `

--- a/vendor/github.com/fgtdev/fortios-sdk-go/sdkcore/system_setting_global.go
+++ b/vendor/github.com/fgtdev/fortios-sdk-go/sdkcore/system_setting_global.go
@@ -16,6 +16,7 @@ type JSONSystemSettingGlobal struct {
 	Hostname     string `json:"hostname"`
 	AdminSport   string `json:"admin-sport"`
 	AdminSSHPort string `json:"admin-ssh-port"`
+	AdminScp     string `json:"admin-scp"`
 }
 
 // JSONCreateSystemSettingGlobalOutput contains the output results for Create API function
@@ -279,7 +280,9 @@ func (c *FortiSDKClient) ReadSystemSettingGlobal(mkey string) (output *JSONSyste
 		if mapTmp["admin-ssh-port"] != nil {
 			output.AdminSSHPort = strconv.Itoa(int(mapTmp["admin-ssh-port"].(float64)))
 		}
-
+		if mapTmp["admin-scp"] != nil {
+			output.AdminScp = mapTmp["admin-scp"].(string)
+		}
 	} else {
 		err = fmt.Errorf("cannot get the right response")
 		return

--- a/website/docs/r/fortios_system_setting_global.html.markdown
+++ b/website/docs/r/fortios_system_setting_global.html.markdown
@@ -22,6 +22,7 @@ resource "fortios_system_setting_global" "test1" {
 	hostname = "mytestFortiGate"
 	admin_sport = 443
 	admin_ssh_port = 22
+	admin_scp = "enable"
 }
 ```
 
@@ -33,6 +34,7 @@ The following arguments are supported:
 * `timezone` - Number corresponding to your time zone from 00 to 86.
 * `admin_sport` - Administrative access port for HTTPS.
 * `admin_ssh_port` - Administrative access port for SSH.
+* `admin_scp` - Enable SCP over SSH
 
 ## Attributes Reference
 The following attributes are exported:
@@ -42,3 +44,4 @@ The following attributes are exported:
 * `hostname` - FortiGate unit's hostname.
 * `admin_sport` - Administrative access port for HTTPS.
 * `admin_ssh_port` - Administrative access port for SSH.
+* `admin_scp` - Enable SCP over SSH


### PR DESCRIPTION
adding admin-scp variable in "config system global" section. This help to enable config file upload

resource "fortios_system_setting_global" "fw1" {
  hostname     = "fw1"
  admintimeout = 460
  admin_scp = "enable"
}