### PR TITLE
.travis-ci.yml: remove non-existent make rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,30 @@
+---
 dist: trusty
 sudo: required
 services:
   - docker
 language: go
 go:
-- "1.11.1"
+  - "1.11.1"
 
 git:
   depth: 1
 
 install:
-# This script is used by the Travis build to install a cookie for
-# go.googlesource.com so rate limits are higher when using `go get` to fetch
-# packages that live there.
-# See: https://github.com/golang/go/issues/12933
-- bash scripts/gogetcookie.sh
-- make tools
+  # This script is used by the Travis build to install a cookie for
+  # go.googlesource.com so rate limits are higher when using `go get` to fetch
+  # packages that live there.
+  # See: https://github.com/golang/go/issues/12933
+  - bash scripts/gogetcookie.sh
 
 script:
-- make lint
-- make test
-- make vendor-status
-- make website-lint
-- make website-test
+  - make test
+  - make website-test
 
 branches:
   only:
-  - master
+    - master
 matrix:
   fast_finish: true
   allow_failures:
-  - go: tip
+    - go: tip


### PR DESCRIPTION
Remove non-existent make rules so that travis-ci tests pass