### PR TITLE
Add ability to set tcp session ttl per service object

### DIFF
--- a/fortios/resource_firewall_object_service.go
+++ b/fortios/resource_firewall_object_service.go
@@ -77,6 +77,11 @@ func resourceFirewallObjectService() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
+			"session_ttl": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0",
+			},
 		},
 	}
 }
@@ -98,6 +103,7 @@ func resourceFirewallObjectServiceCreate(d *schema.ResourceData, m interface{}) 
 	tcpPortrange := d.Get("tcp_portrange").(string)
 	udpPortrange := d.Get("udp_portrange").(string)
 	sctpPortrange := d.Get("sctp_portrange").(string)
+	sessionTTL := d.Get("session_ttl").(string)
 
 	if protocol == "ICMP" {
 		protocolNumber = "1"
@@ -114,6 +120,7 @@ func resourceFirewallObjectServiceCreate(d *schema.ResourceData, m interface{}) 
 		TCPPortrange:   tcpPortrange,
 		UDPPortrange:   udpPortrange,
 		SctpPortrange:  sctpPortrange,
+		SessionTTL:     sessionTTL,
 	}
 	var j2 *forticlient.JSONFirewallObjectServiceFqdn
 	var j3 *forticlient.JSONFirewallObjectServiceIprange
@@ -166,6 +173,7 @@ func resourceFirewallObjectServiceUpdate(d *schema.ResourceData, m interface{}) 
 	tcpPortrange := d.Get("tcp_portrange").(string)
 	udpPortrange := d.Get("udp_portrange").(string)
 	sctpPortrange := d.Get("sctp_portrange").(string)
+	sessionTTL := d.Get("session_ttl").(string)
 
 	j1 := &forticlient.JSONFirewallObjectServiceCommon{
 		Name:           name,
@@ -178,6 +186,7 @@ func resourceFirewallObjectServiceUpdate(d *schema.ResourceData, m interface{}) 
 		TCPPortrange:   tcpPortrange,
 		UDPPortrange:   udpPortrange,
 		SctpPortrange:  sctpPortrange,
+		SessionTTL:     sessionTTL,
 	}
 	var j2 *forticlient.JSONFirewallObjectServiceFqdn
 	var j3 *forticlient.JSONFirewallObjectServiceIprange
@@ -266,6 +275,7 @@ func resourceFirewallObjectServiceRead(d *schema.ResourceData, m interface{}) er
 	d.Set("tcp_portrange", o.TCPPortrange)
 	d.Set("udp_portrange", o.UDPPortrange)
 	d.Set("sctp_portrange", o.SctpPortrange)
+	d.Set("session_ttl", o.SessionTTL)
 
 	return nil
 }

--- a/fortios/resource_firewall_object_service_test.go
+++ b/fortios/resource_firewall_object_service_test.go
@@ -51,6 +51,7 @@ func TestAccFortiOSFirewallObjectService_IPRange(t *testing.T) {
 					resource.TestCheckResourceAttr("fortios_firewall_object_service.test2", "tcp_portrange", "22-33"),
 					resource.TestCheckResourceAttr("fortios_firewall_object_service.test2", "udp_portrange", "44-55"),
 					resource.TestCheckResourceAttr("fortios_firewall_object_service.test2", "sctp_portrange", "66-88"),
+					resource.TestCheckResourceAttr("fortios_firewall_object_service.test2", "session_ttl", "1000"),
 					resource.TestCheckResourceAttr("fortios_firewall_object_service.test2", "comment", "Terraform Test"),
 				),
 			},
@@ -133,6 +134,7 @@ resource "fortios_firewall_object_service" "test2" {
 	tcp_portrange = "22-33"
 	udp_portrange = "44-55"
 	sctp_portrange = "66-88"
+	session_ttl = "1000"
 	comment = "Terraform Test"
 }
 `, name)

--- a/website/docs/r/fortios_firewall_object_service.html.markdown
+++ b/website/docs/r/fortios_firewall_object_service.html.markdown
@@ -71,6 +71,7 @@ The following arguments are supported:
 * `icmptype` - ICMP type.
 * `icmpcode` - ICMP code.
 * `protocol_number` - IP protocol number.
+* `session_ttl` - Custom tcp session TTL.
 * `comment` - Comment.
 
 ## Attributes Reference
@@ -88,5 +89,6 @@ The following attributes are exported:
 * `icmptype` - ICMP type.
 * `icmpcode` - ICMP code.
 * `protocol_number` - IP protocol number.
+* `session_ttl` - Custom tcp session TTL.
 * `comment` - Comment.
 


### PR DESCRIPTION
Adds ability to set  optional tcp session  TTL on Service Object.
Supporting PR in  fgtdev/fortios-sdk-go [PR#8](https://github.com/fgtdev/fortios-sdk-go/pull/8)